### PR TITLE
Support interface of Iterable

### DIFF
--- a/src/main/scala/com/github/tarao/nonempty/CanBuildFrom.scala
+++ b/src/main/scala/com/github/tarao/nonempty/CanBuildFrom.scala
@@ -1,0 +1,35 @@
+package com.github.tarao
+package nonempty
+
+import scala.annotation.implicitNotFound
+import scala.collection.generic.{CanBuildFrom => CollCanBuildFrom}
+
+/** A base trait for builder factories.
+  *
+  * @tparam A  the type of the underlying collection that requests
+  *            a builder to be created.
+  * @tparam B  the element type of the collection to be created.
+  * @tparam To the type of the collection to be created.
+  */
+@implicitNotFound(msg = "Cannot construct a collection of type ${To} with elements of type ${B} based on a collection of type ${A}.")
+sealed trait CanBuildFrom[-A, B, +To] {
+  private[nonempty] def canBuildFrom: CollCanBuildFrom[Iterable[A], B, Any]
+  private[nonempty] def apply(from: Any): To
+}
+object CanBuildFrom {
+  private[nonempty] case class NonEmptyCanBuildFrom[A, B](
+    private[nonempty] val canBuildFrom: CollCanBuildFrom[Iterable[A], B, Iterable[B]]
+  ) extends CanBuildFrom[A, B, NonEmpty[B]] {
+    private[nonempty] def apply(from: Any): NonEmpty[B] =
+      new NonEmpty(from.asInstanceOf[Iterable[B]])
+  }
+  private[nonempty] case class OtherCanBuildFrom[A, B, To](
+    private[nonempty] val canBuildFrom: CollCanBuildFrom[Iterable[A], B, To]
+  ) extends CanBuildFrom[A, B, To] {
+    private[nonempty] def apply(x: Any): To = x.asInstanceOf[To]
+  }
+
+  implicit def nonEmptyCanBuildFrom[A, B](implicit
+    bf: CollCanBuildFrom[Iterable[A], B, Iterable[B]]
+  ): NonEmptyCanBuildFrom[A, B] = NonEmptyCanBuildFrom(bf)
+}

--- a/src/main/scala/com/github/tarao/nonempty/NonEmpty.scala
+++ b/src/main/scala/com/github/tarao/nonempty/NonEmpty.scala
@@ -1,42 +1,354 @@
 package com.github.tarao
 package nonempty
 
+import scala.collection.GenIterable
 import scala.language.implicitConversions
 
-/** A value class for non-empty traversable collections.
+/** A value class for non-empty iterable collections.
   *
   * It is intended to be used as a parameter type to restrict a
   * collection value to be non-empty.  This restriction is guaranteed
   * statically, i.e., it is not possible to pass an empty collection
-  * as a parameter of type NonEmpty[].
+  * as a parameter of type `NonEmpty[]`.
   *
-  * The static safety is guaranteed by two reasons:
-  * 1. there is no way to create an instance of NonEmpty[] other than
-  *    by factory methods provided by singleton object NonEmpty
-  * 2. there is only two factory methods:
-  *    - an implicit conversion from Traversable[T] to
-  *      Option[NonEmpty[T]] where an empty value will be None
-  *    - an apply which takes at least one argument
+  * The static safety is guaranteed by three reasons:
+  *  1. there is no way to create a new instance of `NonEmpty[]` other
+  *     than by factory methods provided by singleton object
+  *     `NonEmpty`
+  *  1. there is only two factory methods:
+  *     - an implicit conversion from `Iterable[A]` to
+  *       `Option[NonEmpty[A]]` where an empty value will be None
+  *     - `NonEmpty.apply`, which takes at least one argument
   *
-  * A value of type NonEmpty[T] can be used as a Traversable[T] by an
-  * implicit conversion from NonEmpty[T] to Traversable[T].
+  * A value of type `NonEmpty[A]` can be used as a `Iterable[A]` by an
+  * implicit conversion from `NonEmpty[A]` to `Iterable[A]`.
+  *
+  * @define thatinfo the class of the returned collection. Where possible,
+  *   `That` is the same class as the current collection class `Repr`,
+  *   but this depends on the element type `B` being admissible for
+  *   that class, which means that an implicit instance of type
+  *   `CanBuildFrom[Repr, B, That]` is found.
+  * @define bfinfo an implicit value of class `CanBuildFrom` which determines
+  *   the result class `That` from the current representation type
+  *   `Repr` and and the new element type `B`.
+  * @define orderDependent
+  *
+  *   Note: might return different results for different runs, unless the
+  *   underlying collection type is ordered.
+  * @define willNotTerminateInf
+  *
+  *   Note: will not terminate for infinite-sized collections.
+  * @define Coll `NonEmpty`
+  * @define coll collection
   */
-class NonEmpty[+T] private (val traversable: Traversable[T]) extends AnyVal {
-  override def toString = traversable.toString
+class NonEmpty[+A] private[nonempty] (
+  private val iterable: Iterable[A]
+) extends AnyVal {
+  override def toString = iterable.toString
+
+  /** Returns a new $coll containing the elements from the left hand
+    *  operand followed by the elements from the right hand
+    *  operand. The element type of the $coll is the most specific
+    *  superclass encompassing the element types of the two operands.
+    *
+    * @param that   the traversable to append.
+    * @tparam B     the element type of the returned collection.
+    * @tparam That  $thatinfo
+    * @param bf     $bfinfo
+    * @return       a new collection of type `That` which contains all elements
+    *               of this $coll followed by all elements of `that`.
+    *
+    * @usecase def ++[B](that: TraversableOnce[B]): $Coll[B]
+    *   @inheritdoc
+    *
+    *   Example:
+    *   {{{
+    *     scala> val a = NonEmpty(1)
+    *     a: NonEmpty[Int] = List(1)
+    *
+    *     scala> val b = NonEmpty(2)
+    *     b: NonEmpty[Int] = List(2)
+    *
+    *     scala> val c = a ++ b
+    *     c: NonEmpty[Int] = List(1, 2)
+    *
+    *     scala> val d = NonEmpty('a')
+    *     d: NonEmpty[Char] = List(a)
+    *
+    *     scala> val e = c ++ d
+    *     e: NonEmpty[AnyVal] = List(1, 2, a)
+    *   }}}
+    *
+    *   @return       a new $coll which contains all elements of this $coll
+    *                 followed by all elements of `that`.
+    */
+  def ++[B >: A, That](that: TraversableOnce[B])(implicit
+    bf: CanBuildFrom[A, B, That]
+  ): That = bf(iterable.++(that)(bf.canBuildFrom))
+
+  /** Partitions this $coll into a map of ${coll}s according to some
+    * discriminator function.
+    *
+    * @param f     the discriminator function.
+    * @tparam K    the type of keys returned by the discriminator function.
+    * @return      A map from keys to ${coll}s such that the following
+    *              invariant holds:
+    *              {{{
+    *                (xs groupBy f)(k) = xs filter (x => f(x) == k)
+    *              }}}
+    *              That is, every key `k` is bound to a $coll of those elements `x`
+    *              for which `f(x)` equals `k`.
+    */
+  def groupBy[K](f: A => K): scala.collection.immutable.Map[K, NonEmpty[A]] =
+    iterable.groupBy(f).mapValues(new NonEmpty(_))
+
+  /** Partitions elements in fixed size ${coll}s.
+    *
+    * @param  size the number of elements per group
+    * @return An iterator producing ${coll}s of size `size`, except the
+    *         last will be less than size `size` if the elements don't
+    *         divide evenly.
+    */
+  def grouped(size: Int): Iterator[NonEmpty[A]] =
+    iterable.grouped(size).map(new NonEmpty(_))
+
+  /** Builds a new collection by applying a function to all elements of
+    * this $coll.
+    *
+    * @param f      the function to apply to each element.
+    * @tparam B     the element type of the returned collection.
+    * @tparam That  $thatinfo
+    * @param bf     $bfinfo
+    * @return       a new collection of type `That` resulting from applying
+    *               the given function `f` to each element of this
+    *               $coll and collecting the results.
+    *
+    * @usecase def map[B](f: A => B): $Coll[B]
+    *   @inheritdoc
+    *   @return       a new $coll resulting from applying the given function
+    *                 `f` to each element of this $coll and collecting
+    *                 the results.
+    */
+  def map[B, That](f: A => B)(implicit
+    bf: CanBuildFrom[A, B, That]
+  ): That = bf(iterable.map(f)(bf.canBuildFrom))
+
+  /** Computes a prefix scan of the elements of the collection.
+    *
+    * Note: The neutral element `z` may be applied more than once.
+    *
+    * @tparam B         element type of the resulting collection
+    * @tparam That      type of the resulting collection
+    * @param z          neutral element for the operator `op`
+    * @param op         the associative operator for the scan
+    * @param bf         combiner factory which provides a combiner
+    *
+    * @return           a new $coll containing the prefix scan of the elements
+    *                    in this $coll
+    */
+  def scan[B >: A, That](z: B)(op: (B, B) => B)(implicit
+    bf: CanBuildFrom[A, B, That]
+  ): That = bf(iterable.scan(z)(op)(bf.canBuildFrom))
+
+  /** Produces a collection containing cumulative results of applying the
+    * operator going left to right.
+    *
+    * $willNotTerminateInf
+    * $orderDependent
+    *
+    * @tparam B      the type of the elements in the resulting collection
+    * @tparam That   the actual type of the resulting collection
+    * @param z       the initial value
+    * @param op      the binary operator applied to the intermediate result
+    *                and the element
+    * @param bf      $bfinfo
+    * @return        collection with intermediate results
+    */
+  def scanLeft[B, That](z: B)(op: (B, A) => B)(implicit
+    bf: CanBuildFrom[A, B, That]
+  ): That = bf(iterable.scanLeft(z)(op)(bf.canBuildFrom))
+
+  /** Produces a collection containing cumulative results of applying
+    * the operator going right to left.
+    * The head of the collection is the last cumulative result.
+    * $willNotTerminateInf
+    * $orderDependent
+    *
+    * Example:
+    * {{{
+    *   NonEmpty(1, 2, 3, 4).scanRight(0)(_ + _) == NonEmpty(10, 9, 7, 4, 0)
+    * }}}
+    *
+    * @tparam B      the type of the elements in the resulting collection
+    * @tparam That   the actual type of the resulting collection
+    * @param z       the initial value
+    * @param op      the binary operator applied to the intermediate result
+    *                and the element
+    * @param bf      $bfinfo
+    * @return        collection with intermediate results
+    */
+  def scanRight[B, That](z: B)(op: (A, B) => B)(implicit
+    bf: CanBuildFrom[A, B, That]
+  ): That = bf(iterable.scanRight(z)(op)(bf.canBuildFrom))
+
+  /** Converts this $coll of pairs into two collections of the first and
+    * second half of each pair.
+    *
+    *    {{{
+    *    val xs = NonEmpty(
+    *               (1, "one"),
+    *               (2, "two"),
+    *               (3, "three")).unzip
+    *    // xs == (NonEmpty(1, 2, 3),
+    *    //        NonEmpty(one, two, three))
+    *    }}}
+    *
+    *  @tparam A1    the type of the first half of the element pairs
+    *  @tparam A2    the type of the second half of the element pairs
+    *  @param asPair an implicit conversion which asserts that the element type
+    *                of this $coll is a pair.
+    *  @return       a pair of ${coll}s, containing the first, respectively
+    *                second half of each element pair of this $coll.
+    */
+  def unzip[A1, A2](implicit
+    asPair: A => (A1, A2)
+  ): (NonEmpty[A1], NonEmpty[A2]) = {
+    val (a1, a2) = iterable.unzip(asPair)
+    (new NonEmpty(a1), new NonEmpty(a2))
+  }
+
+  /** Converts this $coll of triples into three collections of the
+    * first, second, and third element of each triple.
+    *
+    *   {{{
+    *   val xs = NonEmpty(
+    *              (1, "one", '1'),
+    *              (2, "two", '2'),
+    *              (3, "three", '3')).unzip3
+    *   // xs == (NonEmpty(1, 2, 3),
+    *   //        NonEmpty(one, two, three),
+    *   //        NonEmpty(1, 2, 3))
+    *   }}}
+    *
+    * @tparam A1       the type of the first member of the element triples
+    * @tparam A2       the type of the second member of the element triples
+    * @tparam A3       the type of the third member of the element triples
+    * @param asTriple  an implicit conversion which asserts that the element
+    *                  type of this $coll is a triple.
+    * @return          a triple of ${coll}s, containing the first, second,
+    *                  respectively third member of each element
+    *                  triple of this $coll.
+    */
+  def unzip3[A1, A2, A3](implicit
+    asTriple: A => (A1, A2, A3)
+  ): (NonEmpty[A1], NonEmpty[A2], NonEmpty[A3]) = {
+    val (a1, a2, a3) = iterable.unzip3(asTriple)
+    (new NonEmpty(a1), new NonEmpty(a2), new NonEmpty(a3))
+  }
+
+  /** Returns a $coll formed from this $coll and another iterable
+    * collection by combining corresponding elements in pairs.
+    * If one of the two collections is shorter than the other,
+    * placeholder elements are used to extend the shorter collection
+    * to the length of the longer.
+    *
+    * @param that     the iterable providing the second half of each result pair
+    * @param thisElem the element to be used to fill up the result if this
+    *                 $coll is shorter than `that`.
+    * @param thatElem the element to be used to fill up the result if `that` is
+    *                 shorter than this $coll.
+    * @return         a new collection of type `That` containing pairs
+    *                 consisting of corresponding elements of this
+    *                 $coll and `that`. The length of the returned
+    *                 collection is the maximum of the lengths of this
+    *                 $coll and `that`. If this $coll is shorter than
+    *                 `that`, `thisElem` values are used to pad the
+    *                 result. If `that` is shorter than this $coll,
+    *                 `thatElem` values are used to pad the result.
+    *
+    * @usecase def zipAll[B](that: Iterable[B], thisElem: A, thatElem: B): $Coll[(A, B)]
+    *   @inheritdoc
+    *
+    *   $orderDependent
+    *
+    *   @param   that   the iterable providing the second half of each result
+    *                   pair
+    *   @param thisElem the element to be used to fill up the result if this
+    *                   $coll is shorter than `that`.
+    *   @param thatElem the element to be used to fill up the result if `that`
+    *                   is shorter than this $coll.
+    *   @tparam  B      the type of the second half of the returned pairs
+    *   @return         a new $coll containing pairs consisting of
+    *                   corresponding elements of this $coll and
+    *                   `that`. The length of the returned collection
+    *                   is the maximum of the lengths of this $coll
+    *                   and `that`. If this $coll is shorter than
+    *                   `that`, `thisElem` values are used to pad the
+    *                   result. If `that` is shorter than this $coll,
+    *                   `thatElem` values are used to pad the result.
+    */
+  def zipAll[B, A1 >: A, That](
+    that: GenIterable[B],
+    thisElem: A1,
+    thatElem: B
+  )(implicit bf: CanBuildFrom[A, (A1, B), That]): That =
+    bf(iterable.zipAll(that, thisElem, thatElem)(bf.canBuildFrom))
+
+  /** Zips this $coll with its indices.
+    *
+    *  @tparam  A1    the type of the first half of the returned pairs (this
+    *                 is always a supertype of the collection's
+    *                 element type `A`).
+    *  @tparam  That  the class of the returned collection. Where possible,
+    *                 `That` is the same class as the current
+    *                 collection class `Repr`, but this depends on the
+    *                 element type `(A1, Int)` being admissible for
+    *                 that class, which means that an implicit
+    *                 instance of type `CanBuildFrom[Repr, (A1, Int),
+    *                 That]`. is found.
+    *  @param  bf     an implicit value of class `CanBuildFrom` which
+    *                 determines the result class `That` from the
+    *                 current representation type `Repr` and the new
+    *                 element type `(A1, Int)`.
+    *  @return        a new collection of type `That` containing pairs
+    *                 consisting of all elements of this $coll paired
+    *                 with their index. Indices start at `0`.
+    *
+    *  @usecase def zipWithIndex: $Coll[(A, Int)]
+    *    @inheritdoc
+    *
+    *    $orderDependent
+    *
+    *    @return        a new $coll containing pairs consisting of all elements
+    *                   of this $coll paired with their index. Indices
+    *                   start at `0`.
+    *    @example
+    *      `NonEmpty("a", "b", "c").zipWithIndex = NonEmpty(("a", 0), ("b", 1), ("c", 2))`
+    *
+    */
+  def zipWithIndex[A1 >: A, That](implicit
+    bf: CanBuildFrom[A, (A1, Int), That]
+  ): That = bf(iterable.zipWithIndex(bf.canBuildFrom))
 }
 object NonEmpty {
-  /** Convert a Traversable[T] to Option[NonEmpty[T]].
-    * There is no way to directly convert a Traversable[T] into a NonEmpty[T].
+  /** Convert a `Traversable[A]` to `Option[NonEmpty[A]]`.
+    *
+    * There is no way to directly convert a `Traversable[A]` into a `NonEmpty[A]`.
     */
-  implicit def fromTraversable[T](t: Traversable[T]): Option[NonEmpty[T]] =
-    if (t.isEmpty) None
-    else Some(new NonEmpty[T](t))
+  def fromTraversable[A](t: Traversable[A]): Option[NonEmpty[A]] = t.toIterable
 
-  /** Automatically treat a NonEmpty[T] as a Traversable[T]. */
-  implicit def toTraversable[T](ne: NonEmpty[T]): Traversable[T] =
-    ne.traversable
+  /** Convert a `Iterable[A]` to `Option[NonEmpty[A]]`.
+    *
+    * There is no way to directly convert a `Iterable[A]` into a `NonEmpty[A]`.
+    */
+  implicit def fromIterable[A](it: Iterable[A]): Option[NonEmpty[A]] =
+    if (it.isEmpty) None
+    else Some(new NonEmpty[A](it))
 
-  /** Directly create a NonEmpty[T] by passing no less than one parameter. */
-  def apply[T](head: T, elements: T*): NonEmpty[T] =
-    new NonEmpty[T](head +: Seq(elements: _*))
+  /** Treat a `NonEmpty[A]` as a `Iterable[A]`. */
+  implicit def toIterable[A](ne: NonEmpty[A]): Iterable[A] = ne.iterable
+
+  /** Directly create a `NonEmpty[A]` by passing no less than one parameter. */
+  def apply[A](head: A, elements: A*): NonEmpty[A] =
+    new NonEmpty[A](head +: Seq(elements: _*))
 }

--- a/src/main/scala/com/github/tarao/nonempty/package.scala
+++ b/src/main/scala/com/github/tarao/nonempty/package.scala
@@ -1,0 +1,14 @@
+package com.github.tarao
+
+import scala.collection.generic.{CanBuildFrom => CollCanBuildFrom}
+
+package object nonempty {
+  /** Provides a CanBuildFrom instance that builds a specific target
+    * collection (`To') irrespective of the original collection
+    * (`From').
+    */
+  def breakOut[From, T, To](implicit
+    bf: CollCanBuildFrom[Nothing, T, To]
+  ): CanBuildFrom[From, T, To] =
+    CanBuildFrom.OtherCanBuildFrom(scala.collection.breakOut)
+}

--- a/src/test/scala/com/github/tarao/nonempty/NonEmptySpec.scala
+++ b/src/test/scala/com/github/tarao/nonempty/NonEmptySpec.scala
@@ -169,6 +169,26 @@ class NonEmptySpec extends FunSpec
       neC.toSeq(2) shouldBe ((3, 2))
     }
 
+    it("should return Iterable if the number of elements may reduce") {
+      val l1 = NonEmpty(Seq(1, 2), Seq(3, 4)).flatten
+      l1 shouldBe a[Iterable[_]]
+
+      val l2 = NonEmpty(Seq(), Seq()).flatten
+      l2 shouldBe a[Iterable[_]]
+
+      val l3 = NonEmpty(1, 2, 3).drop(1)
+      l3 shouldBe a[Iterable[_]]
+
+      val l4 = NonEmpty(1, 2, 3).drop(5)
+      l4 shouldBe a[Iterable[_]]
+
+      val l5 = NonEmpty(1, 2, 3).take(1)
+      l5 shouldBe a[Iterable[_]]
+
+      val l6 = NonEmpty(1, 2, 3).take(0)
+      l6 shouldBe a[Iterable[_]]
+    }
+
     it("should map to desired type by using breakOut") {
       val m: Map[Int, Int] = NonEmpty(1, 2, 3).map(i => i -> i*2)(breakOut)
       m shouldBe Map(1 -> 2, 2 -> 4, 3 -> 6)

--- a/src/test/scala/com/github/tarao/nonempty/NonEmptySpec.scala
+++ b/src/test/scala/com/github/tarao/nonempty/NonEmptySpec.scala
@@ -1,29 +1,32 @@
 package com.github.tarao
 package nonempty
 
-class NonEmptySpec extends UnitSpec {
+import org.scalatest.{FunSpec, Matchers, OptionValues, Inside, Inspectors}
+
+class NonEmptySpec extends FunSpec
+    with Matchers with OptionValues with Inside with Inspectors {
   import scala.collection.mutable.ArrayBuffer
 
   object AsParameterOf {
-    def optionNonEmpty[T](ne: Option[NonEmpty[T]]) {}
-    def nonEmpty[T](ne: NonEmpty[T]) {}
-    def traversable[T](t: Traversable[T]) {}
+    def optionNonEmpty[T](ne: Option[NonEmpty[T]]): Unit = {}
+    def nonEmpty[T](ne: NonEmpty[T]): Unit = {}
+    def iterable[T](t: Iterable[T]): Unit = {}
   }
 
-  def traversable[T](ne: NonEmpty[T]) {
+  def iterable[T](ne: NonEmpty[T]): Unit = {
     // as a variable
-    val t1: Traversable[T] = ne
+    val it1: Iterable[T] = ne
 
     // as a parameter
-    AsParameterOf.traversable(ne)
+    AsParameterOf.iterable(ne)
 
     // methods
     ne.map(_.toString)
     ne.mkString
   }
 
-  def identical[T](ne: NonEmpty[T], t: Traversable[T]) {
-    ne should equal(NonEmpty.fromTraversable(t).get)
+  def identical[T](ne: NonEmpty[T], t: Iterable[T]): Unit = {
+    ne should equal(NonEmpty.fromIterable(t).get)
     val t1: Traversable[T] = ne
     t1 should equal(t)
     ne.toString should equal (t.toString)
@@ -31,7 +34,7 @@ class NonEmptySpec extends UnitSpec {
   }
 
   describe("A context of type Option[NonEmpty[]]") {
-    it("should accept a Traversable[]") {
+    it("should accept a Iterable[]") {
       // as a varibable
       val ne1: Option[NonEmpty[Int]] = Seq(1, 2, 3)
       val ne2: Option[NonEmpty[Int]] = Seq.empty[Int]
@@ -47,7 +50,7 @@ class NonEmptySpec extends UnitSpec {
   }
 
   describe("A context of type Option[NonEmpty[]]") {
-    it("should not accept a Traversable[]") {
+    it("should not accept a Iterable[]") {
       // as a varibable
       assertTypeError("val ne1: NonEmpty[Int] = Seq(1, 2, 3)")
       assertTypeError("val ne2: NonEmpty[Int] = Seq.empty[Int]")
@@ -75,31 +78,108 @@ class NonEmptySpec extends UnitSpec {
       assertTypeError("val ne = NonEmpty()")
     }
 
-    it("cannot be directly instantiated from outside") {
-      assertTypeError("val ne = new NonEmpty[Int](Seq(1))")
+    it("should behave like a Iterable[]") {
+      it should behave like iterable (NonEmpty(1))
+      it should behave like iterable (NonEmpty(1, 2, 3))
     }
 
-    it("should behave like a Traversable[]") {
-      it should behave like traversable (NonEmpty(1))
-      it should behave like traversable (NonEmpty(1, 2, 3))
-    }
-
-    it("should be identical to its Traversable[] counterpart") {
-      val t1: Traversable[Int] = Seq(1)
+    it("should be identical to its Iterable[] counterpart") {
+      val t1: Iterable[Int] = Seq(1)
       val ne1: Option[NonEmpty[Int]] = t1
       it should behave like identical (ne1.get, t1)
 
-      val t2: Traversable[Int] = Seq(1, 2, 3)
+      val t2: Iterable[Int] = Seq(1, 2, 3)
       val ne2: Option[NonEmpty[Int]] = t2
       it should behave like identical (ne2.get, t2)
 
-      val t3: Traversable[Int] = ArrayBuffer(1)
+      val t3: Iterable[Int] = ArrayBuffer(1)
       val ne3: Option[NonEmpty[Int]] = t3
       it should behave like identical (ne3.get, t3)
 
-      val t4: Traversable[Int] = ArrayBuffer(1, 2, 3)
+      val t4: Iterable[Int] = ArrayBuffer(1, 2, 3)
       val ne4: Option[NonEmpty[Int]] = t4
       it should behave like identical (ne4.get, t4)
+    }
+
+    it("should preserve the collection type as NonEmpty[]") {
+      val ne1 = NonEmpty(1, 2, 3) ++ Seq(4)
+      ne1 shouldBe a[NonEmpty[_]]
+      ne1.toSeq shouldBe Seq(1, 2, 3, 4)
+
+      val m2 = NonEmpty(1, 2, 3, 4, 5, 6).groupBy(_ % 2 == 0)
+      m2(true) shouldBe a[NonEmpty[_]]
+      m2(true).toSeq shouldBe Seq(2, 4, 6)
+      m2(false) shouldBe a[NonEmpty[_]]
+      m2(false).toSeq shouldBe Seq(1, 3, 5)
+
+      val v3 = NonEmpty(1, 2, 3, 4, 5).grouped(2).toVector
+      v3(0) shouldBe a[NonEmpty[_]]
+      v3(0).toSeq shouldBe Seq(1, 2)
+      v3(1) shouldBe a[NonEmpty[_]]
+      v3(1).toSeq shouldBe Seq(3, 4)
+      v3(2) shouldBe a[NonEmpty[_]]
+      v3(2).toSeq shouldBe Seq(5)
+
+      val ne4 = NonEmpty(1, 2, 3).map(_ * 2)
+      ne4 shouldBe a[NonEmpty[_]]
+      ne4.toSeq shouldBe Seq(2, 4, 6)
+
+      val ne5 = NonEmpty(1, 2, 3, 4).scan(0)((a, b) => a + b)
+      ne5 shouldBe a[NonEmpty[_]]
+      ne5.toSeq shouldBe Seq(0, 1, 3, 6, 10)
+
+      val ne6 = NonEmpty(1, 2, 3, 4).scanLeft("0")((a, b) => a + b)
+      ne6 shouldBe a[NonEmpty[_]]
+      ne6.toSeq shouldBe Seq("0", "01", "012", "0123", "01234")
+
+      val ne7 = NonEmpty(1, 2, 3, 4).scanRight("5")((a, b) => a + b)
+      ne7 shouldBe a[NonEmpty[_]]
+      ne7.toSeq shouldBe Seq("12345", "2345", "345", "45", "5")
+
+      val ne8 = NonEmpty((1, "foo"), (2, "bar"), (3, "baz")).unzip
+      ne8._1 shouldBe a[NonEmpty[_]]
+      ne8._1.toSeq shouldBe Seq(1, 2, 3)
+      ne8._2 shouldBe a[NonEmpty[_]]
+      ne8._2.toSeq shouldBe Seq("foo", "bar", "baz")
+
+      val ne9 = NonEmpty((1, "foo", 100), (2, "bar", 200), (3, "baz", 300)).unzip3
+      ne9._1 shouldBe a[NonEmpty[_]]
+      ne9._1.toSeq shouldBe Seq(1, 2, 3)
+      ne9._2 shouldBe a[NonEmpty[_]]
+      ne9._2.toSeq shouldBe Seq("foo", "bar", "baz")
+      ne9._3 shouldBe a[NonEmpty[_]]
+      ne9._3.toSeq shouldBe Seq(100, 200, 300)
+
+      val neA = NonEmpty(1, 2, 3).zipAll(Seq("foo", "bar", "baz"), 0, "")
+      neA shouldBe a[NonEmpty[_]]
+      neA.toSeq(0) shouldBe ((1, "foo"))
+      neA.toSeq(1) shouldBe ((2, "bar"))
+      neA.toSeq(2) shouldBe ((3, "baz"))
+
+      val neB = NonEmpty(1, 2, 3).zipAll(Seq(), 0, "qux")
+      neB shouldBe a[NonEmpty[_]]
+      neB.toSeq(0) shouldBe ((1, "qux"))
+      neB.toSeq(1) shouldBe ((2, "qux"))
+      neB.toSeq(2) shouldBe ((3, "qux"))
+
+      val neC = NonEmpty(1, 2, 3).zipWithIndex
+      neC shouldBe a[NonEmpty[_]]
+      neC.toSeq(0) shouldBe ((1, 0))
+      neC.toSeq(1) shouldBe ((2, 1))
+      neC.toSeq(2) shouldBe ((3, 2))
+    }
+
+    it("should map to desired type by using breakOut") {
+      val m: Map[Int, Int] = NonEmpty(1, 2, 3).map(i => i -> i*2)(breakOut)
+      m shouldBe Map(1 -> 2, 2 -> 4, 3 -> 6)
+    }
+  }
+
+  describe("Backward compatibility") {
+    it("can be constructed from a traersable") {
+      val Some(ne) = NonEmpty.fromTraversable(Seq(1, 2, 3))
+      ne shouldBe a[NonEmpty[_]]
+      ne.toSeq shouldBe Seq(1, 2, 3)
     }
   }
 }

--- a/src/test/scala/com/github/tarao/nonempty/UnitSpec.scala
+++ b/src/test/scala/com/github/tarao/nonempty/UnitSpec.scala
@@ -1,7 +1,0 @@
-package com.github.tarao
-package nonempty
-
-import org.scalatest.{FunSpec, Matchers, OptionValues, Inside, Inspectors}
-
-abstract class UnitSpec extends FunSpec
-    with Matchers with OptionValues with Inside with Inspectors

--- a/src/test/scala/com/github/tarao/nonemptytest/NonEmptyFromOutsideSpec.scala
+++ b/src/test/scala/com/github/tarao/nonemptytest/NonEmptyFromOutsideSpec.scala
@@ -1,0 +1,14 @@
+package com.github.tarao
+package nonemptytest
+
+import org.scalatest.{FunSpec, Matchers, OptionValues, Inside, Inspectors}
+import nonempty.NonEmpty
+
+class NonEmptyFromOutsideSpec extends FunSpec
+    with Matchers with OptionValues with Inside with Inspectors {
+  describe("A value of NonEmpty") {
+    it("cannot be directly instantiated from outside") {
+      assertTypeError("val ne = new NonEmpty[Int](Seq(1))")
+    }
+  }
+}


### PR DESCRIPTION
- Change the underlying collection type: `Traversable` -> `Iterable`
- Make methods of `Iterable` callable on a `NonEmpty`
- A methods which preserves the number of elements now preserves the return type as well (i.e. it returns a `NonEmpty`)
