### PR TITLE
Construct `CanBuildFrom` in apparently type-safe way.

### DIFF
--- a/src/main/scala/com/github/tarao/nonempty/CanBuildFrom.scala
+++ b/src/main/scala/com/github/tarao/nonempty/CanBuildFrom.scala
@@ -13,13 +13,13 @@ import scala.collection.mutable.Builder
   * @tparam To the type of the collection to be created.
   */
 @implicitNotFound(msg = "Cannot construct a collection of type ${To} with elements of type ${B} based on a collection of type ${A}.")
-sealed trait CanBuildFrom[-A, B, +To] {
+sealed trait CanBuildFrom[-A, B, +To] extends Any {
   private[nonempty] def canBuildFrom: CollCanBuildFrom[Iterable[A], B, To]
 }
 object CanBuildFrom {
   private[nonempty] case class NonEmptyCanBuildFrom[A, B](
-    private val bf: CollCanBuildFrom[Iterable[A], B, Iterable[B]]
-  ) extends CanBuildFrom[A, B, NonEmpty[B]] {
+    val bf: CollCanBuildFrom[Iterable[A], B, Iterable[B]]
+  ) extends AnyVal with CanBuildFrom[A, B, NonEmpty[B]] {
     private type From = Iterable[A]
     private type To = NonEmpty[B]
     private[nonempty] def canBuildFrom: CollCanBuildFrom[From, B, To] =
@@ -31,8 +31,11 @@ object CanBuildFrom {
       }
   }
   private[nonempty] case class OtherCanBuildFrom[A, B, To](
-    private[nonempty] val canBuildFrom: CollCanBuildFrom[Iterable[A], B, To]
-  ) extends CanBuildFrom[A, B, To]
+    val bf: CollCanBuildFrom[Iterable[A], B, To]
+  ) extends AnyVal with CanBuildFrom[A, B, To] {
+    private type From = Iterable[A]
+    private[nonempty] def canBuildFrom: CollCanBuildFrom[From, B, To] = bf
+  }
 
   implicit def nonEmptyCanBuildFrom[A, B](implicit
     bf: CollCanBuildFrom[Iterable[A], B, Iterable[B]]

--- a/src/main/scala/com/github/tarao/nonempty/NonEmpty.scala
+++ b/src/main/scala/com/github/tarao/nonempty/NonEmpty.scala
@@ -84,7 +84,7 @@ class NonEmpty[+A] private[nonempty] (
     */
   def ++[B >: A, That](that: TraversableOnce[B])(implicit
     bf: CanBuildFrom[A, B, That]
-  ): That = bf(iterable.++(that)(bf.canBuildFrom))
+  ): That = iterable.++(that)(bf.canBuildFrom)
 
   /** Partitions this $coll into a map of ${coll}s according to some
     * discriminator function.
@@ -131,7 +131,7 @@ class NonEmpty[+A] private[nonempty] (
     */
   def map[B, That](f: A => B)(implicit
     bf: CanBuildFrom[A, B, That]
-  ): That = bf(iterable.map(f)(bf.canBuildFrom))
+  ): That = iterable.map(f)(bf.canBuildFrom)
 
   /** Computes a prefix scan of the elements of the collection.
     *
@@ -148,7 +148,7 @@ class NonEmpty[+A] private[nonempty] (
     */
   def scan[B >: A, That](z: B)(op: (B, B) => B)(implicit
     bf: CanBuildFrom[A, B, That]
-  ): That = bf(iterable.scan(z)(op)(bf.canBuildFrom))
+  ): That = iterable.scan(z)(op)(bf.canBuildFrom)
 
   /** Produces a collection containing cumulative results of applying the
     * operator going left to right.
@@ -166,7 +166,7 @@ class NonEmpty[+A] private[nonempty] (
     */
   def scanLeft[B, That](z: B)(op: (B, A) => B)(implicit
     bf: CanBuildFrom[A, B, That]
-  ): That = bf(iterable.scanLeft(z)(op)(bf.canBuildFrom))
+  ): That = iterable.scanLeft(z)(op)(bf.canBuildFrom)
 
   /** Produces a collection containing cumulative results of applying
     * the operator going right to left.
@@ -189,7 +189,7 @@ class NonEmpty[+A] private[nonempty] (
     */
   def scanRight[B, That](z: B)(op: (A, B) => B)(implicit
     bf: CanBuildFrom[A, B, That]
-  ): That = bf(iterable.scanRight(z)(op)(bf.canBuildFrom))
+  ): That = iterable.scanRight(z)(op)(bf.canBuildFrom)
 
   /** Converts this $coll of pairs into two collections of the first and
     * second half of each pair.
@@ -292,7 +292,7 @@ class NonEmpty[+A] private[nonempty] (
     thisElem: A1,
     thatElem: B
   )(implicit bf: CanBuildFrom[A, (A1, B), That]): That =
-    bf(iterable.zipAll(that, thisElem, thatElem)(bf.canBuildFrom))
+    iterable.zipAll(that, thisElem, thatElem)(bf.canBuildFrom)
 
   /** Zips this $coll with its indices.
     *
@@ -328,7 +328,7 @@ class NonEmpty[+A] private[nonempty] (
     */
   def zipWithIndex[A1 >: A, That](implicit
     bf: CanBuildFrom[A, (A1, Int), That]
-  ): That = bf(iterable.zipWithIndex(bf.canBuildFrom))
+  ): That = iterable.zipWithIndex(bf.canBuildFrom)
 }
 object NonEmpty {
   /** Convert a `Traversable[A]` to `Option[NonEmpty[A]]`.

--- a/src/main/scala/com/github/tarao/nonempty/package.scala
+++ b/src/main/scala/com/github/tarao/nonempty/package.scala
@@ -10,5 +10,5 @@ package object nonempty {
   def breakOut[From, T, To](implicit
     bf: CollCanBuildFrom[Nothing, T, To]
   ): CanBuildFrom[From, T, To] =
-    CanBuildFrom.OtherCanBuildFrom(scala.collection.breakOut)
+    CanBuildFrom.OtherCanBuildFrom(scala.collection.breakOut(bf))
 }


### PR DESCRIPTION
Avoid `asInstanceOf`.
